### PR TITLE
Remove pip upgrade and whitespace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,11 @@ MAINTAINER niall.robinson@informaticslab.co.uk
 
 RUN apt-get update && apt-get install -y git
 
-RUN git clone https://github.com/met-office-lab/cloud-processing-config.git config 
+RUN git clone https://github.com/met-office-lab/cloud-processing-config.git config
 
 ADD requirements.txt requirements.txt
-ADD scheduler.py scheduler.py 
+ADD scheduler.py scheduler.py
 
-RUN pip install --upgrade pip
 RUN pip install -r requirements.txt
 
 CMD ./scheduler.py


### PR DESCRIPTION
Relies on the pip upgrade being moved to the parent docker image.

https://github.com/niallrobinson/docker-iris/pull/2
